### PR TITLE
Conditioned assert whether script ID is valid when using Eluna

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -46,7 +46,9 @@ CreatureAI::CreatureAI(Creature* creature, uint32 scriptId) noexcept
     : UnitAI(creature), me(creature), _boundary(nullptr),
       _negateBoundary(false), _scriptId(scriptId ? scriptId : creature->GetScriptId()), _isEngaged(false), _moveInLOSLocked(false)
 {
-    ASSERT(_scriptId, "A CreatureAI was initialized with an invalid scriptId!");
+    #ifndef ELUNA
+        ASSERT(_scriptId, "A CreatureAI was initialized with an invalid scriptId!");
+    #endif
 }
 
 CreatureAI::~CreatureAI()


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Adds condition whether to assert scriptId validity to avoid crashing the core when initializing creature AI using Elena


**Tests performed:**
✅ Builds
✅ Tested ingame